### PR TITLE
Fix lazyload images

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -190,6 +190,7 @@
     /* Let highlight.js stylesheet handle token colors, inherit pre bg */
     .hljs{ background: transparent; color: inherit; }
   </style>
+  <script src="/assets/js/lazysizes.min.js" async=""></script>
 </head>
 <body>
   <!-- Fixed decorations -->


### PR DESCRIPTION
## Summary
- load lazysizes script in `post.html` so images with `blur-up lazyload` class work

## Testing
- `bundle install` (fails: Net::HTTPClientException 403 "Forbidden")
- `bundle exec jekyll build` (fails: bundler: command not found: jekyll)

------
https://chatgpt.com/codex/tasks/task_e_688ec3bc3c748326a0e30a134f14d7a1