### PR TITLE
feat: track visitors with plausible

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,10 @@ permalink: /:title/
 google_analytics: UA-120232408-2
 fb_appid:
 
+# Plausible Analytics configuration
+plausible_domain: alessandroferrari.live
+plausible_api_key:
+
 # Collection setting
 collections:
   posts:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -16,6 +16,12 @@
   </small>
 </footer>
 <script src="/assets/js/main.js" defer="defer"></script>
+<script
+  src="/assets/js/users.js"
+  defer
+  data-plausible-domain="{{ site.plausible_domain }}"
+  data-plausible-api-key="{{ site.plausible_api_key }}"
+></script>
 <script>
   var galite = galite || {};
   galite.UA = "{{ site.google_analytics }}";

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -229,6 +229,12 @@
   <!-- Scripts -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
   <script>hljs.highlightAll();</script>
+  <script
+    src="/assets/js/users.js"
+    defer
+    data-plausible-domain="{{ site.plausible_domain }}"
+    data-plausible-api-key="{{ site.plausible_api_key }}"
+  ></script>
 </body>
 </html>
 

--- a/_sass/klise/_custom.scss
+++ b/_sass/klise/_custom.scss
@@ -42,3 +42,23 @@ body[data-theme="dark"] {
         align-items: center;
     }
 }
+
+.user-stats {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    padding: 6px 10px;
+    background-color: $white;
+    border: 1px solid $light;
+    border-radius: 4px;
+    font-size: $small-font-size;
+    color: $gray;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    z-index: 1000;
+}
+
+body[data-theme="dark"] .user-stats {
+    background-color: $dark-black;
+    border-color: $dark-light;
+    color: $dark-gray;
+}

--- a/assets/js/users.js
+++ b/assets/js/users.js
@@ -1,0 +1,46 @@
+/**
+ * Display current active users using Plausible Analytics API.
+ * Requires `data-plausible-domain` and `data-plausible-api-key`
+ * attributes on the script tag loading this file.
+ */
+(function() {
+  if (window.__userStatsLoaded) return;
+  window.__userStatsLoaded = true;
+
+  function createBox(count) {
+    var box = document.createElement('div');
+    box.className = 'user-stats';
+    box.id = 'user-stats';
+    box.textContent = 'Current active users: ';
+    var span = document.createElement('span');
+    span.id = 'user-count';
+    span.textContent = count;
+    box.appendChild(span);
+    document.body.appendChild(box);
+  }
+
+  function updateCount(domain, apiKey) {
+    var url = 'https://plausible.io/api/v1/stats/realtime/visitors?site_id=' + encodeURIComponent(domain);
+    fetch(url, { headers: { Authorization: 'Bearer ' + apiKey } })
+      .then(function(resp) { return resp.json(); })
+      .then(function(data) {
+        var count = data && data.results ? data.results : 0;
+        var box = document.getElementById('user-stats');
+        if (!box) createBox(count);
+        else document.getElementById('user-count').textContent = count;
+      })
+      .catch(function() {
+        var box = document.getElementById('user-stats');
+        if (box) box.style.display = 'none';
+      });
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    var script = document.querySelector('script[data-plausible-domain]');
+    if (!script) return;
+    var domain = script.dataset.plausibleDomain;
+    var apiKey = script.dataset.plausibleApiKey;
+    if (!domain || !apiKey) return;
+    updateCount(domain, apiKey);
+  });
+})();


### PR DESCRIPTION
## Summary
- replace removed CountAPI with Plausible Analytics real-time visitors
- add script attributes and config entries to supply domain and API key

## Testing
- `bundle install`
- `bundle exec jekyll build` *(fails: Could not find gem 'jekyll-toc')*

------
https://chatgpt.com/codex/tasks/task_e_68b9b27fa7048326b47b521652d00c52